### PR TITLE
fix: normalize DVLA error responses

### DIFF
--- a/api/vrm.js
+++ b/api/vrm.js
@@ -24,11 +24,17 @@ export default async function handler(req, res) {
       }
     );
 
-    const data = await dvlaRes.json().catch(() => ({}));
+    const data = await dvlaRes.json().catch(() => null);
 
     if (!dvlaRes.ok) {
+      const message =
+        typeof data === 'string'
+          ? data
+          : typeof data?.message === 'string'
+          ? data.message
+          : null;
       return res.status(dvlaRes.status).json({
-        error: data?.message || data || 'DVLA lookup failed',
+        error: message || 'DVLA lookup failed',
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure API returns string errors when DVLA responds with invalid JSON or no message

## Testing
- `node - <<'NODE'
import handler from './api/vrm.js';

const req = { method: 'POST', body: { vrm: 'AB12CDE' } };
const res = {
  headers: {},
  statusCode: 200,
  setHeader(key, value){ this.headers[key]=value; },
  status(code){ this.statusCode=code; return this; },
  json(data){ console.log(JSON.stringify({status:this.statusCode,data})); },
  end(){ console.log('end',this.statusCode); }
};

global.fetch = async () => ({
  ok:false,
  status:500,
  json: async()=>{ throw new Error('oops'); }
});
await handler(req, res);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb5a2fb8832386e0736a27759d84